### PR TITLE
ci: locate file:line in golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
+        args: "--out-${NO_FUTURE}format colored-line-number"
 
   build:
     name: Build and test - Go ${{ matrix.go_version }}


### PR DESCRIPTION
Signed-off-by: Jiangnan Jia <jnan0806@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: 
   for English: https://opensergo.io/docs/community/contribution-guidance
   for Chinese: https://opensergo.io/zh-cn/docs/community/contribution-guidance
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Now, the golangci-lint can not locate  the `file:line` when lint occurs error,like following:

<img width="885" alt="image" src="https://user-images.githubusercontent.com/43714056/208854118-ccd9df6e-b34e-4d8a-82c8-54186fe1ca40.png">


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #1. Otherwise, add "NONE" -->

### Describe how you did it
add args according https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648


### Describe how to verify it

<img width="768" alt="image" src="https://user-images.githubusercontent.com/43714056/208854291-c10e4881-81c4-4d61-9e1f-c28dd8bd2789.png">


### Special notes for reviews