### PR TITLE
bugfix: fix bug of overriding value when parsing config array in for loop.

### DIFF
--- a/pkg/client/subscribeconfig_streamobserver.go
+++ b/pkg/client/subscribeconfig_streamobserver.go
@@ -263,8 +263,8 @@ func decodeSubscribeData(kindName string, dataSlice []*anypb.Any) ([]protoreflec
 		return nil, errors.New("unrecognized config kind: " + kindName)
 	}
 	var decodeDataSlice []protoreflect.ProtoMessage
-	protoMessage := configKindMetadata.GetKindPbMessageType().New().Interface()
 	for _, data := range dataSlice {
+		protoMessage := configKindMetadata.GetKindPbMessageType().New().Interface()
 		if err := anypb.UnmarshalTo(data, protoMessage, proto.UnmarshalOptions{}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Jiangnan Jia <jnan0806@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: 
   for English: https://opensergo.io/docs/community/contribution-guidance
   for Chinese: https://opensergo.io/zh-cn/docs/community/contribution-guidance
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it？
when parse array data from subscriber, the next data will override the prev one in the data array， by following:
<img width="967" alt="image" src="https://user-images.githubusercontent.com/43714056/210675394-ce614ad5-d149-44b0-b3e2-302ad2a1e53d.png">

### Describe how you did it？
move it into the `for loop`
<img width="907" alt="image" src="https://user-images.githubusercontent.com/43714056/210675435-15b3d6e6-94e8-41a8-908e-df86d69ff168.png">

